### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "npm run test:contracts",
     "test:contracts": "npm run test:contracts:solidity && npm run test:contracts:js",
     "test:contracts:solidity": "wafr ./src/contracts",
-    "test:contracts:js": "npm run deploy:testrpc && npm run test:conracts:js:mocha",
+    "test:contracts:js": "npm run deploy:testrpc && npm run test:contracts:js:mocha",
     "test:conracts:js:mocha": "mocha src/contracts/**/*test.**.js -R spec --timeout 2000000 --compilers js:babel-core/register --require ./internals/mocha/index",
     "lint": "npm run lint:js",
     "lint:eslint": "eslint --ignore-path .gitignore --ignore-pattern **/**.min.js",


### PR DESCRIPTION
Hi, this is a small fix to a typo that threw an error when I was initially setting up ethjs-contract-boilerplate. After this fix I no longer see the error when running tests.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/ethjs/ethjs-contract-boilerplate/blob/master/.github/CONTRIBUTING.md)
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

